### PR TITLE
refactor: move field options to the top

### DIFF
--- a/features/tables/components/OptionsWrapper.tsx
+++ b/features/tables/components/OptionsWrapper.tsx
@@ -4,7 +4,7 @@ const OptionWrapper = ({
   helpText,
   children,
 }: {
-  helpText?: string;
+  helpText?: string | ReactNode;
   children: ReactNode;
 }) => {
   return (

--- a/pages/data-sources/[dataSourceId]/edit/tables/[tableName]/columns/[columnName].tsx
+++ b/pages/data-sources/[dataSourceId]/edit/tables/[tableName]/columns/[columnName].tsx
@@ -301,8 +301,19 @@ function ColumnEdit() {
                 </FormControl>
               </OptionWrapper>
 
+              <InspectorComponent
+                column={localColumn}
+                setColumnOptions={setColumnOptions}
+              />
+
               <OptionWrapper
-                helpText={`Some fields you don't want to show at all. By disconnecting the field it will be hidden from all views.`}
+                helpText={
+                  <>
+                    Some fields you don't want to show at all. By disconnecting
+                    the field it will be hidden from all views and{" "}
+                    <strong>all responses</strong>.
+                  </>
+                }
               >
                 <FormLabel>Disconnect field</FormLabel>
                 <Checkbox
@@ -327,13 +338,11 @@ You can control where the field is visible here.`}
               >
                 <CheckboxGroup
                   value={localColumn.baseOptions.visibility}
-                  onChange={(value) => {
-                    console.log("value->", value);
-
-                    return setColumnOptions(localColumn, {
+                  onChange={(value) =>
+                    setColumnOptions(localColumn, {
                       "baseOptions.visibility": value,
-                    });
-                  }}
+                    })
+                  }
                 >
                   <Stack direction="column">
                     <Checkbox
@@ -526,11 +535,6 @@ You can control where the field is visible here.`}
                     </FormControl>
                   </OptionWrapper>
                 )}
-
-              <InspectorComponent
-                column={localColumn}
-                setColumnOptions={setColumnOptions}
-              />
             </div>
           </div>
         )}


### PR DESCRIPTION
I always felt like the specific field options were hidden below. This PR brings them to the top.