### PR TITLE
refactor: get more information about the field from the SQL column

### DIFF
--- a/features/fields/index.ts
+++ b/features/fields/index.ts
@@ -5,9 +5,9 @@ import {
   CheckCircleIcon,
   HashtagIcon,
   KeyIcon,
+  PhotographIcon,
   SelectorIcon,
-  TrendingUpIcon,
-  PhotographIcon
+  TrendingUpIcon
 } from "@heroicons/react/outline";
 import { ElementType } from "react";
 import { Views } from "./enums";

--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -17,6 +17,7 @@ import {
   DataSourceCredentials,
   ForeignKeyInfo,
   ISQLQueryService,
+  QueryServiceFieldOptions,
   SQLDataSourceTypes,
   SqlColumnOptions,
 } from "./types";
@@ -691,8 +692,10 @@ abstract class AbstractQueryService implements ISQLQueryService {
           : undefined;
 
         // Try and find if the user defined this type in the DB
+        const baseOptionsFromColumnInfo =
+          this.getFieldOptionsFromColumnInfo(column);
         const fieldType =
-          storedColumn?.fieldType || this.getFieldTypeFromColumnInfo(column);
+          storedColumn?.fieldType || baseOptionsFromColumnInfo.fieldType;
 
         return {
           ...column,
@@ -803,7 +806,9 @@ abstract class AbstractQueryService implements ISQLQueryService {
     return foreignKeys;
   }
 
-  abstract getFieldTypeFromColumnInfo(column: ColumnWithBaseOptions): FieldType;
+  abstract getFieldOptionsFromColumnInfo(
+    column: ColumnWithBaseOptions
+  ): QueryServiceFieldOptions;
   public abstract getCredentials(): PgCredentials | MysqlCredentials;
 }
 

--- a/plugins/data-sources/abstract-sql-query-service/types.d.ts
+++ b/plugins/data-sources/abstract-sql-query-service/types.d.ts
@@ -1,5 +1,5 @@
 import { IQueryService } from "../types";
-import type { Column } from "@/components/fields/types";
+import type { Column, FieldType } from "@/features/fields/types";
 import type { Knex } from "knex";
 
 export type AxiosErrorWithMessage = {
@@ -106,3 +106,7 @@ export interface ISQLQueryService extends IQueryService {
   public getParsedCredentials(): DataSourceCredentials;
   public getParsedSSHCredentials(): DataSourceCredentials;
 }
+
+export type QueryServiceFieldOptions = {
+  fieldType: FieldType;
+};

--- a/plugins/data-sources/mssql/QueryService.ts
+++ b/plugins/data-sources/mssql/QueryService.ts
@@ -1,4 +1,7 @@
-import { ColumnWithBaseOptions } from "../abstract-sql-query-service/types";
+import {
+  ColumnWithBaseOptions,
+  QueryServiceFieldOptions,
+} from "../abstract-sql-query-service/types";
 import { FieldType } from "@/features/fields/types";
 import { MysqlCredentials } from "../mysql/types";
 import { idColumns } from "@/features/fields";
@@ -40,30 +43,33 @@ class QueryService extends AbstractQueryService {
     return client;
   }
 
-  public getFieldTypeFromColumnInfo(column: ColumnWithBaseOptions): FieldType {
-    if (column.foreignKeyInfo) {
-      return "Association";
-    }
+  public getFieldOptionsFromColumnInfo(
+    column: ColumnWithBaseOptions
+  ): QueryServiceFieldOptions {
+    let fieldType: FieldType = "Text";
 
     const { name } = column;
     switch (column.dataSourceInfo.type) {
-      default:
       case "char":
       case "varchar":
       case "binary":
       case "varbinary":
-        return "Text";
+        fieldType = "Text";
+        break;
 
       case "text":
       case "nchar":
       case "nvarchar":
-        return "Textarea";
+        fieldType = "Textarea";
+        break;
 
       case "enum":
-        return "Select";
+        fieldType = "Select";
+        break;
 
       case "bit":
-        return "Boolean";
+        fieldType = "Boolean";
+        break;
 
       case "datetime":
       case "datetime2":
@@ -72,10 +78,12 @@ class QueryService extends AbstractQueryService {
       case "time":
       case "timestamp":
       case "datetimeoffset":
-        return "DateTime";
+        fieldType = "DateTime";
+        break;
 
       case "json":
-        return "Json";
+        fieldType = "Json";
+        break;
 
       case "int":
       case "tinyint":
@@ -88,9 +96,21 @@ class QueryService extends AbstractQueryService {
       case "money":
       case "float":
       case "real":
-        if (idColumns.includes(name)) return "Id";
-        else return "Number";
+        if (idColumns.includes(name)) {
+          fieldType = "Id";
+        } else {
+          fieldType = "Number";
+        }
+        break;
     }
+
+    if (column.foreignKeyInfo) {
+      fieldType = "Association";
+    }
+
+    return {
+      fieldType,
+    };
   }
 }
 

--- a/plugins/data-sources/mysql/QueryService.ts
+++ b/plugins/data-sources/mysql/QueryService.ts
@@ -1,4 +1,7 @@
-import { ColumnWithBaseOptions } from "../abstract-sql-query-service/types";
+import {
+  ColumnWithBaseOptions,
+  QueryServiceFieldOptions,
+} from "../abstract-sql-query-service/types";
 import { FieldType } from "@/features/fields/types";
 import { MysqlCredentials } from "./types";
 import { idColumns } from "@/features/fields";
@@ -14,14 +17,13 @@ class QueryService extends AbstractQueryService {
     return credentials;
   }
 
-  public getFieldTypeFromColumnInfo(column: ColumnWithBaseOptions): FieldType {
-    if (column.foreignKeyInfo) {
-      return "Association";
-    }
+  public getFieldOptionsFromColumnInfo(
+    column: ColumnWithBaseOptions
+  ): QueryServiceFieldOptions {
+    let fieldType: FieldType = "Text";
 
     const { name } = column;
     switch (column.dataSourceInfo.type) {
-      default:
       case "char":
       case "varchar":
       case "binary":
@@ -30,24 +32,29 @@ class QueryService extends AbstractQueryService {
       case "tinytext":
       case "enum":
       case "set":
-        return "Text";
+        fieldType = "Text";
+        break;
 
       case "enum":
-        return "Select";
+        fieldType = "Select";
+        break;
 
       case "tinyint":
       case "bit":
-        return "Boolean";
+        fieldType = "Boolean";
+        break;
 
       case "date":
       case "datetime":
       case "timestamp":
       case "time":
       case "year":
-        return "DateTime";
+        fieldType = "DateTime";
+        break;
 
       case "json":
-        return "Json";
+        fieldType = "Json";
+        break;
 
       case "blob":
       case "text":
@@ -55,7 +62,8 @@ class QueryService extends AbstractQueryService {
       case "mediumtext":
       case "longblob":
       case "longtext":
-        return "Textarea";
+        fieldType = "Textarea";
+        break;
 
       case "int":
       case "smallint":
@@ -65,9 +73,19 @@ class QueryService extends AbstractQueryService {
       case "double":
       case "decimal":
       case "numeric":
-        if (idColumns.includes(name)) return "Id";
-        else return "Number";
+        if (idColumns.includes(name)) {
+          fieldType = "Id";
+        } else {
+          fieldType = "Number";
+        }
+        break;
     }
+
+    if (column.foreignKeyInfo) {
+      fieldType = "Association";
+    }
+
+    return { fieldType };
   }
 }
 

--- a/plugins/data-sources/mysql/schema.ts
+++ b/plugins/data-sources/mysql/schema.ts
@@ -3,6 +3,10 @@ import Joi from "joi";
 export const schema = Joi.object({
   name: Joi.string().min(3).required(),
   type: Joi.string().allow("mysql").required(),
+  options: Joi.object({
+    connectsWithSSH: Joi.boolean(),
+    connectsWithSSHKey: Joi.boolean(),
+  }),
   credentials: Joi.object({
     host: Joi.string().required(),
     port: Joi.number().required(),
@@ -16,6 +20,8 @@ export const schema = Joi.object({
     port: Joi.number().allow(""),
     user: Joi.string().allow(""),
     password: Joi.string().allow(""),
+    key: Joi.any(),
+    passphrase: Joi.string().allow(""),
   }),
-  organizationId: Joi.string().required(),
+  organizationId: Joi.number().required()
 });

--- a/plugins/data-sources/postgresql/QueryService.ts
+++ b/plugins/data-sources/postgresql/QueryService.ts
@@ -1,4 +1,7 @@
-import { ColumnWithBaseOptions } from "../abstract-sql-query-service/types";
+import {
+  ColumnWithBaseOptions,
+  QueryServiceFieldOptions,
+} from "../abstract-sql-query-service/types";
 import { FieldType } from "@/features/fields/types";
 import { PgCredentials, PgLegacyCredentials } from "./types";
 import { idColumns } from "@/features/fields";
@@ -33,10 +36,10 @@ class QueryService extends AbstractQueryService {
     return credentials;
   }
 
-  public getFieldTypeFromColumnInfo(column: ColumnWithBaseOptions): FieldType {
-    if (column.foreignKeyInfo) {
-      return "Association";
-    }
+  public getFieldOptionsFromColumnInfo(
+    column: ColumnWithBaseOptions
+  ): QueryServiceFieldOptions {
+    let fieldType: FieldType = "Text";
 
     const { name } = column;
     switch (column.dataSourceInfo.type) {
@@ -45,23 +48,28 @@ class QueryService extends AbstractQueryService {
       case "character varying":
       case "interval":
       case "name":
-        return "Text";
+        fieldType = "Text";
+        break;
       case "boolean":
       case "bit":
-        return "Boolean";
+        fieldType = "Boolean";
+        break;
       case "timestamp without time zone":
       case "timestamp with time zone":
       case "time without time zone":
       case "time with time zone":
       case "date":
-        return "DateTime";
+        fieldType = "DateTime";
+        break;
       case "json":
       case "jsonb":
-        return "Json";
+        fieldType = "Json";
+        break;
       case "text":
       case "xml":
       case "bytea":
-        return "Textarea";
+        fieldType = "Textarea";
+        break;
       case "integer":
       case "bigint":
       case "numeric":
@@ -71,9 +79,19 @@ class QueryService extends AbstractQueryService {
       case "real":
       case "double precision":
       case "money":
-        if (idColumns.includes(name)) return "Id";
-        else return "Number";
+        if (idColumns.includes(name)) {
+          fieldType = "Id";
+        } else {
+          fieldType = "Number";
+        }
+        break;
     }
+
+    if (column.foreignKeyInfo) {
+      fieldType = "Association";
+    }
+
+    return { fieldType };
   }
 }
 


### PR DESCRIPTION
This PR preps the codebase for BST-102. It renames `getFieldTypeFromColumnInfo` to `getFieldOptionsFromColumnInfo` and returns more than just the type. We can use this method to return options to the fields like if the `DateTime` field should show only the time or only the date.