### PR TITLE
[BST-167] fix: date filters empty

### DIFF
--- a/features/tables/components/Filter.tsx
+++ b/features/tables/components/Filter.tsx
@@ -48,8 +48,6 @@ const CONDITIONS_WITHOUT_VALUE = [
   BooleanFilterConditions.is_false,
   BooleanFilterConditions.is_null,
   BooleanFilterConditions.is_not_null,
-  DateFilterConditions.is_empty,
-  DateFilterConditions.is_not_empty,
   DateFilterConditions.is_null,
   DateFilterConditions.is_not_null,
   SelectFilterConditions.is_empty,
@@ -113,16 +111,16 @@ const Filter = ({
 
   const changeFilterColumn = (columnName: string) => {
     const column = columns.find((c) => c.name === columnName) as Column;
-    const condition = getDefaultFilterCondition(column.fieldType);
 
+    // Get the default condition and option/value for the new filter.
+    const condition = getDefaultFilterCondition(column.fieldType);
     let option;
-    if (filter.column.fieldType === "DateTime") {
+    if (column.fieldType === "DateTime") {
       option = "today";
     }
-
-    let value = "";
+    let value;
     if (column.fieldType === "Select") {
-      value = (column?.fieldOptions?.options as string).split(",")[0].trim();
+      value = (column?.fieldOptions?.options as string).split(",")[0].trim() || "";
     }
 
     // If the filter is in a group (!isUndefined(parentIdx)), we need to update the filters array of that group.
@@ -156,13 +154,27 @@ const Filter = ({
 
   const changeFilterCondition = (condition: FilterConditions) => {
     let option;
-    if (filter.column.fieldType === "DateTime") {
+    if (isDateFilter) {
       if (condition === DateFilterConditions.is_within) {
         option = "past_week";
-      } else {
+      } else if (
+        condition === DateFilterConditions.is ||
+        condition === DateFilterConditions.is_not ||
+        condition === DateFilterConditions.is_before ||
+        condition === DateFilterConditions.is_after ||
+        condition === DateFilterConditions.is_on_or_before ||
+        condition === DateFilterConditions.is_on_or_after
+      ) {
         option = "today";
       }
     }
+
+    const isSelectFilterWithoutValue =
+      isSelectFilter &&
+      (condition === SelectFilterConditions.is_empty ||
+        condition === SelectFilterConditions.is_not_empty ||
+        condition === SelectFilterConditions.is_null ||
+        condition === SelectFilterConditions.is_not_null);
 
     if (!isUndefined(parentIdx)) {
       const groupFilter = filters[parentIdx] as IFilterGroup;
@@ -171,6 +183,7 @@ const Filter = ({
         ...groupFilter.filters[idx],
         condition,
         option,
+        value: isSelectFilterWithoutValue ? "" : groupFilter.filters[idx].value,
       };
 
       updateFilter(parentIdx, {
@@ -182,6 +195,7 @@ const Filter = ({
         ...filter,
         condition,
         option,
+        value: isSelectFilterWithoutValue ? "" : filter.value,
       });
     }
   };

--- a/features/tables/index.ts
+++ b/features/tables/index.ts
@@ -104,8 +104,6 @@ export enum DateFilterConditions {
   is_on_or_before = "is_on_or_before",
   is_on_or_after = "is_on_or_after",
   is_within = "is_within",
-  is_empty = "is_empty",
-  is_not_empty = "is_not_empty",
   is_null = "is_null",
   is_not_null = "is_not_null",
 }

--- a/features/tables/types.d.ts
+++ b/features/tables/types.d.ts
@@ -22,10 +22,10 @@ export type FilterConditions =
 export type IFilter = {
   column: Column;
   columnName: string;
+  verb: FilterVerb;
   condition: FilterConditions;
   option?: string;
-  value: string;
-  verb: FilterVerb;
+  value?: string;
   isBase?: boolean;
 };
 

--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -43,12 +43,10 @@ const getCondition = (filter: IFilter) => {
     case StringFilterConditions.starts_with:
     case StringFilterConditions.ends_with:
     case StringFilterConditions.is_empty:
-    case DateFilterConditions.is_empty:
     case SelectFilterConditions.contains:
       return "LIKE";
     case StringFilterConditions.not_contains:
     case StringFilterConditions.is_not_empty:
-    case DateFilterConditions.is_not_empty:
     case SelectFilterConditions.not_contains:
       return "NOT LIKE";
     case IntFilterConditions.gt:
@@ -84,8 +82,6 @@ const getValue = (filter: IFilter) => {
       return `%${filter.value}`;
     case StringFilterConditions.is_not_empty:
     case StringFilterConditions.is_empty:
-    case DateFilterConditions.is_not_empty:
-    case DateFilterConditions.is_empty:
     case SelectFilterConditions.is_not_empty:
     case SelectFilterConditions.is_empty:
       return "";
@@ -104,7 +100,25 @@ const getValue = (filter: IFilter) => {
     case SelectFilterConditions.is:
     case SelectFilterConditions.is_not:
     default:
-      return filter.value;
+      return filter.value || getDefaultFilterValue(filter);
+    }
+};
+
+const getDefaultFilterValue = (filter: IFilter) => {
+  switch (filter.column.fieldType) {
+    case "Id":
+    case "Number":
+    case "Association":
+      return 0;
+    case "Boolean":
+      return "true";
+    case "DateTime":
+      return new Date().toUTCString();
+    case "Select":
+      return "";
+    default:
+    case "Text":
+      return "";
   }
 };
 
@@ -136,7 +150,7 @@ const addFilterGroupToQuery = (
   }
 };
 
-const getDateRange = (filterOption: string, filterValue: string) => {
+const getDateRange = (filterOption: string, filterValue: string | undefined) => {
   let today = new Date();
   let from, to;
   switch (filterOption) {
@@ -244,7 +258,7 @@ const getDateRange = (filterOption: string, filterValue: string) => {
 
       return [from, to];
     case "exact_date":
-      if (filterValue != "") {
+      if (filterValue != "" && filterValue != undefined) {
         today = new Date(filterValue);
       }
       today.setUTCHours(0, 0, 0, 0);


### PR DESCRIPTION
for date filters I removed the options isEmpty and isNotEmpty since we cannot check for that using knex and postgres and also notion filters dont have those options
besides this, I refactored a bit the defaults for filters and wrong display in FilterCompactView