### PR TITLE
fix: remove rogue semicolon that adds scrollbars

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -103,7 +103,7 @@ function MyApp({ Component, pageProps }: AppProps) {
               {/* Conditionally enable Intercom */}
               {isString(intercomAppId) && (
                 <IntercomProvider appId={intercomAppId}>
-                  <Component {...pageProps} />;
+                  <Component {...pageProps} />
                 </IntercomProvider>
               )}
 


### PR DESCRIPTION
This rogue semicolon adds unneccesarry scrollbars