### PR TITLE
[BST-135] fix: count fails when there's not id field

### DIFF
--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -532,7 +532,7 @@ abstract class AbstractQueryService implements ISQLQueryService {
     if (filters) {
       addFiltersToQuery(query, filters);
     }
-    const [{ count }] = await query.count("id", { as: "count" });
+    const [{ count }] = await query.count("*", { as: "count" });
 
     return parseInt(count as string, 10);
   }


### PR DESCRIPTION
# Description

The count query fails when there's no ID column

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
