### PR TITLE
[BST-195] feature: add mssql integration

### DIFF
--- a/features/fields/index.ts
+++ b/features/fields/index.ts
@@ -105,6 +105,7 @@ export const makeField = ({
 };
 
 export const iconForField = (field: Column): ElementType => {
+  // console.log('field->', field)
   if (field.primaryKey) return KeyIcon;
 
   switch (field.fieldType) {
@@ -179,7 +180,11 @@ export const getFilteredColumns = (
 ): Column[] => {
   if (isArray(columns)) {
     return (
-      columns
+      columns.filter((column:Column) => {
+        // console.log('column->', column)
+
+        return column;
+      })
         // Remove fields that should be hidden on index
         .filter((column: Column) =>
           column.baseOptions.visibility.includes(view)

--- a/features/fields/index.ts
+++ b/features/fields/index.ts
@@ -105,7 +105,6 @@ export const makeField = ({
 };
 
 export const iconForField = (field: Column): ElementType => {
-  // console.log('field->', field)
   if (field.primaryKey) return KeyIcon;
 
   switch (field.fieldType) {
@@ -180,11 +179,7 @@ export const getFilteredColumns = (
 ): Column[] => {
   if (isArray(columns)) {
     return (
-      columns.filter((column:Column) => {
-        // console.log('column->', column)
-
-        return column;
-      })
+      columns
         // Remove fields that should be hidden on index
         .filter((column: Column) =>
           column.baseOptions.visibility.includes(view)

--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -778,13 +778,13 @@ abstract class AbstractQueryService implements ISQLQueryService {
     );
 
     // Filter out fields that are unsupported.
-    const filteredColumns = this.filterOutColumns(columns);
+    const supportedColumns = this.filterOutUnsupportedColumns(columns);
 
     // @todo: fetch foreign keys before responding
-    return filteredColumns as [];
+    return supportedColumns as [];
   }
 
-  filterOutColumns(columns: Column<SqlColumnOptions>[]) {
+  public filterOutUnsupportedColumns(columns: Column<SqlColumnOptions>[]) {
     return columns;
   }
 

--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -777,6 +777,8 @@ abstract class AbstractQueryService implements ISQLQueryService {
       })
     );
 
+    // todo - filter out fields that are unsupported
+
     // @todo: fetch foreign keys before responding
     return columns as [];
   }

--- a/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
+++ b/plugins/data-sources/abstract-sql-query-service/AbstractQueryService.ts
@@ -777,10 +777,15 @@ abstract class AbstractQueryService implements ISQLQueryService {
       })
     );
 
-    // todo - filter out fields that are unsupported
+    // Filter out fields that are unsupported.
+    const filteredColumns = this.filterOutColumns(columns);
 
     // @todo: fetch foreign keys before responding
-    return columns as [];
+    return filteredColumns as [];
+  }
+
+  filterOutColumns(columns: Column<SqlColumnOptions>[]) {
+    return columns;
   }
 
   private async computeValue(

--- a/plugins/data-sources/index.ts
+++ b/plugins/data-sources/index.ts
@@ -29,17 +29,17 @@ export const availableDataSources = [
     beta: true,
   },
   {
+    id: "mssql",
+    label: "MSSQL",
+    enabled: false,
+    beta: true,
+  },
+  {
     id: "stripe",
     label: "Stripe",
     enabled: true,
     comingSoon: true,
     beta: false,
-  },
-  {
-    id: "mssql",
-    label: "MSSQL",
-    comingSoon: true,
-    enabled: false,
   },
   {
     id: "amazon_redshift",

--- a/plugins/data-sources/mssql/QueryService.ts
+++ b/plugins/data-sources/mssql/QueryService.ts
@@ -56,6 +56,7 @@ class QueryService extends AbstractQueryService {
     let fieldType: FieldType = "Text";
 
     const { name } = column;
+
     switch (column.dataSourceInfo.type) {
       case "char":
       case "varchar":
@@ -67,6 +68,7 @@ class QueryService extends AbstractQueryService {
       case "text":
       case "nchar":
       case "nvarchar":
+      case "xml":
         fieldType = "Textarea";
         break;
 

--- a/plugins/data-sources/mssql/QueryService.ts
+++ b/plugins/data-sources/mssql/QueryService.ts
@@ -46,7 +46,7 @@ class QueryService extends AbstractQueryService {
   public getFieldOptionsFromColumnInfo(
     column: ColumnWithBaseOptions
   ): QueryServiceFieldOptions {
-    const fieldOptions: Record<string, unknown> = {};
+    let fieldOptions: Record<string, unknown> = {};
     let fieldType: FieldType = "Text";
 
     const { name } = column;
@@ -80,6 +80,33 @@ class QueryService extends AbstractQueryService {
       case "timestamp":
       case "datetimeoffset":
         fieldType = "DateTime";
+
+        switch (column.dataSourceInfo.type) {
+          case "datetime":
+          case "timestamp":
+            fieldOptions = {
+              ...fieldOptions,
+              showDate: true,
+              showTime: true,
+            };
+            break;
+          case "time":
+            fieldOptions = {
+              ...fieldOptions,
+              showDate: false,
+              showTime: true,
+            };
+            break;
+          // case "year":
+          case "date":
+            fieldOptions = {
+              ...fieldOptions,
+              showDate: true,
+              showTime: false,
+            };
+            break;
+        }
+
         break;
 
       case "json":

--- a/plugins/data-sources/mssql/QueryService.ts
+++ b/plugins/data-sources/mssql/QueryService.ts
@@ -45,8 +45,8 @@ class QueryService extends AbstractQueryService {
     return client;
   }
 
-  public filterOutColumns(columns: Column<SqlColumnOptions>[]) {
-    return columns.filter((column) => column?.dataSourceInfo?.type !== "timestamp");
+  public filterOutUnsupportedColumns(columns: Column<SqlColumnOptions>[]) {
+    return columns.filter((column) => column?.dataSourceInfo?.type !== "timestamp" && column?.dataSourceInfo?.type !== "geometry");
   }
 
   public getFieldOptionsFromColumnInfo(
@@ -91,6 +91,7 @@ class QueryService extends AbstractQueryService {
 
         switch (column.dataSourceInfo.type) {
           case "datetime":
+          case "datetime2":
           case "timestamp":
             fieldOptions = {
               ...fieldOptions,
@@ -132,6 +133,7 @@ class QueryService extends AbstractQueryService {
       case "money":
       case "float":
       case "real":
+      case "decimal":
         if (idColumns.includes(name)) {
           fieldType = "Id";
         } else {

--- a/plugins/data-sources/mssql/QueryService.ts
+++ b/plugins/data-sources/mssql/QueryService.ts
@@ -1,6 +1,8 @@
+import { Column } from './../../../features/fields/types.d';
 import {
   ColumnWithBaseOptions,
   QueryServiceFieldOptions,
+  SqlColumnOptions,
 } from "../abstract-sql-query-service/types";
 import { FieldType } from "@/features/fields/types";
 import { MysqlCredentials } from "../mysql/types";
@@ -41,6 +43,10 @@ class QueryService extends AbstractQueryService {
     });
 
     return client;
+  }
+
+  public filterOutColumns(columns: Column<SqlColumnOptions>[]) {
+    return columns.filter((column) => column?.dataSourceInfo?.type !== "timestamp");
   }
 
   public getFieldOptionsFromColumnInfo(


### PR DESCRIPTION
# Add mssql integration

Fixes BST-195

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Docker
1. Setup mssql db on docker image (https://docs.microsoft.com/en-gb/sql/linux/quickstart-install-connect-docker?view=sql-server-ver15&pivots=cs1-bash) (you need to create the DB)
2. Create db
3. Connect to db through TablePlus
4. Use [testingFieldTypes.sql.zip](https://github.com/basetool-io/basetool/files/7497375/testingFieldTypes.sql.zip) to setup a table with all field types.
5. Tested creation, edit, delete.
 
## DigitalOcean
1. Turn on the droplet [here](https://cloud.digitalocean.com/droplets/273937379/graphs?i=79b11a&period=hour)
2. Add DigitalOcean Droplet URL: microsoftsqlserver://SA:capitol.WEB.underact@46.101.183.62/TestDB