### PR TITLE
[BST-197] feature: capture user timezone on login/register

### DIFF
--- a/features/api/ApiService.ts
+++ b/features/api/ApiService.ts
@@ -164,6 +164,7 @@ class ApiService {
     password: string;
     firstName?: string;
     lastName?: string;
+    lastKnownTimezone?: string;
   }): Promise<ApiResponse> {
     const { data } = await Api.post(`${this.apiUrl}/auth/register`, payload);
 

--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -11,13 +11,14 @@ export const createUser = async (data: {
   firstName?: string;
   lastName?: string;
   organization: string;
+  lastKnownTimezone?: string;
 }): Promise<
   | (User & {
       organizations: OrganizationUser[];
     })
   | undefined
 > => {
-  const { email, firstName, lastName, password, organization } = data;
+  const { email, firstName, lastName, password, organization, lastKnownTimezone } = data;
 
   if (!email) return;
 
@@ -39,6 +40,7 @@ export const createUser = async (data: {
         password,
         firstName,
         lastName,
+        lastKnownTimezone,
       },
       include: {
         organizations: true,

--- a/features/auth/signupSchema.ts
+++ b/features/auth/signupSchema.ts
@@ -12,4 +12,5 @@ export const schema = Joi.object({
   organization: Joi.string().label("Organization").required(),
   firstName: Joi.string().label("First name").allow(""),
   lastName: Joi.string().label("Last name").allow(""),
+  lastKnownTimezone: Joi.string().label("Last known timezone").allow(""),
 });

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -22,6 +22,20 @@ function createIntercomUserHash(user: User | undefined): string | undefined {
   return data.digest("hex");
 }
 
+// Update the user's last known timezone on each login.
+async function updateUserLastKnownTimezone(user: User, lastKnownTimezone: string | undefined) {
+  if (user?.email && lastKnownTimezone) {
+    await prisma.user.updateMany({
+      where: {
+        email: user.email,
+      },
+      data: {
+        lastKnownTimezone,
+      },
+    });
+  }
+}
+
 // For more information on each option (and a full list of options) go to
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
@@ -39,6 +53,7 @@ export default NextAuth({
         email: string;
         username: string;
         password: string;
+        lastKnownTimezone?: string;
       }) {
         const user = await prisma.user.findUnique({
           where: {
@@ -54,6 +69,8 @@ export default NextAuth({
         );
 
         if (passwordIsValid) {
+          updateUserLastKnownTimezone(user, credentials?.lastKnownTimezone);
+
           return user;
         }
 

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -43,6 +43,7 @@ const handler = async (
     firstName: payload.firstName,
     lastName: payload.lastName,
     organization: payload.organization,
+    lastKnownTimezone: payload.lastKnownTimezone,
   };
 
   const user = await createUser(data);

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -5,6 +5,7 @@ import {
   FormLabel,
   Input,
 } from "@chakra-ui/react";
+import { getBrowserTimezone } from "@/lib/time";
 import { signIn, useSession } from "next-auth/client";
 import { toast } from "react-toastify";
 import { useRouter } from "next/router";
@@ -29,10 +30,12 @@ export default function SignIn() {
 
   const handleSubmit = async () => {
     setIsDisabled(true);
+
     const response = await signIn("credentials", {
       redirect: false,
       email,
       password,
+      lastKnownTimezone: getBrowserTimezone(),
     });
 
     if (!response) return;
@@ -60,7 +63,7 @@ export default function SignIn() {
       <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <div  className="relative mx-auto w-[200px] h-[54px] my-2">
-            <Image src="/img/logo_text_black.png" layout="fill" width="200" height="54" alt="Basetool Logo" />
+            <Image src="/img/logo_text_black.png" layout="fill" alt="Basetool Logo" />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             Sign in to your account

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -6,6 +6,7 @@ import {
   FormLabel,
   Input,
 } from "@chakra-ui/react";
+import { getBrowserTimezone } from "@/lib/time";
 import { getCsrfToken, useSession } from "next-auth/client";
 import { isEmpty } from "lodash";
 import { joiResolver } from "@hookform/resolvers/joi";
@@ -54,7 +55,7 @@ function Register() {
   }, [session]);
 
   const onSubmit = async (formData: FormFields) => {
-    const response = await api.createUser(formData);
+    const response = await api.createUser({...formData, lastKnownTimezone: getBrowserTimezone()});
     setIsLoading(true);
 
     if (response.ok) {
@@ -90,7 +91,7 @@ function Register() {
       <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <div  className="relative mx-auto w-[200px] h-[54px] my-2">
-            <Image src="/img/logo_text_black.png" layout="fill" width="200" height="54" alt="Basetool Logo" />
+            <Image src="/img/logo_text_black.png" layout="fill" alt="Basetool Logo" />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             Sign up for an account

--- a/prisma/migrations/20211110111825_add_last_known_timezone_to_users/migration.sql
+++ b/prisma/migrations/20211110111825_add_last_known_timezone_to_users/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastKnownTimezone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,21 +96,23 @@ model Session {
 }
 
 model User {
-  id             Int                @id @default(autoincrement())
-  email          String             @unique @db.VarChar(255)
-  emailVerified  DateTime?
-  password       String             @default("") @db.VarChar(255)
-  image          String?
-  firstName      String?            @db.VarChar(255)
-  lastName       String?            @db.VarChar(255)
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
-  lastLoggedInAt DateTime?
-  organizations  OrganizationUser[]
-  accounts       Account[]
-  sessions       Session[]
-  views          View[]
-  activities     Activity[]
+  id                Int       @id @default(autoincrement())
+  email             String    @unique @db.VarChar(255)
+  emailVerified     DateTime?
+  password          String    @default("") @db.VarChar(255)
+  image             String?
+  firstName         String?   @db.VarChar(255)
+  lastName          String?   @db.VarChar(255)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  lastLoggedInAt    DateTime?
+  lastKnownTimezone String?
+
+  organizations OrganizationUser[]
+  accounts      Account[]
+  sessions      Session[]
+  views         View[]
+  activities    Activity[]
 }
 
 model VerificationRequest {
@@ -173,7 +175,7 @@ model Activity {
   organizationId Int
   action         String       @db.VarChar(255)
   changes        Json?        @default("{}")
-  createdAt DateTime @default(now())
+  createdAt      DateTime     @default(now())
 
   @@index([dataSourceId])
   @@index([viewId])


### PR DESCRIPTION
# Description

Capture user timezone on login/register.

The tz has to be captured from the FE and sent to the server.

Fixes # BST-197

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing using my browser and also changing browser's tz.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
