### PR TITLE
[BST-220] fix: datetime fields are sending updates on record update even when not needed

### DIFF
--- a/plugins/fields/DateTime/Edit.tsx
+++ b/plugins/fields/DateTime/Edit.tsx
@@ -121,7 +121,7 @@ const Edit = ({
         dbValue = parsedValue.toUTC();
       }
 
-      setValue(name, dbValue, {
+      setValue(name, dbValue.toString(), {
         shouldValidate: true,
         shouldDirty: true,
         shouldTouch: true,


### PR DESCRIPTION
# Description

The problem happened bcs datetime field edit was sending a DateTime type value and the diff checker compared with the string value coming from db. The solution is to send the date as a string.

Fixes BST-220

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
