### PR TITLE
[BST-265] fix: missing found foreign record crashes records api call

### DIFF
--- a/features/data-sources/components/DataSourcesBlock.tsx
+++ b/features/data-sources/components/DataSourcesBlock.tsx
@@ -65,7 +65,7 @@ const DataSourcesBlock = () => {
                     </div>
                     <br />
                     {organization?.name && (
-                      <div className="text-sm">{organization.name}</div>
+                      <div className="text-sm"><strong>Organization</strong>: {organization.name}</div>
                     )}
                   </div>
                 </PageWrapper.Block>

--- a/features/organizations/components/OrganizationsBlock.tsx
+++ b/features/organizations/components/OrganizationsBlock.tsx
@@ -69,7 +69,7 @@ const OrganizationsBlock = () => {
                   )}
                   {rolesByOrganizationId[org.id] && (
                     <div className="text-sm">
-                      Your role: {rolesByOrganizationId[org.id]}
+                      <strong>Your role</strong>: {rolesByOrganizationId[org.id]}
                     </div>
                   )}
                 </PageWrapper.Block>

--- a/features/records/index.ts
+++ b/features/records/index.ts
@@ -67,9 +67,7 @@ export const hydrateRecords = async (
 
       return hydratedRecordsWithAssociations;
     } catch (error) {
-      console.log("error->", error);
-
-return hydratedRecords;
+      return hydratedRecords;
     }
   } else {
     return hydratedRecords;
@@ -89,11 +87,6 @@ const hydrateAssociations = async (
     const foreignIds = records.map((record: any) => record[column.name]);
     const foreignTableName = column.foreignKeyInfo.foreignTableName as string;
 
-    console.log(
-      "uniq(foreignIds).toString()->",
-      foreignIds,
-      uniq(foreignIds).filter(Boolean).toString()
-    );
     const filters: Record<string, any> = [
       {
         columnName: "id",

--- a/features/records/index.ts
+++ b/features/records/index.ts
@@ -6,7 +6,6 @@ import { getForeignName } from "@/plugins/fields/Association/helpers";
 import { isArray, isEmpty, isNull, merge, uniq } from "lodash";
 import { runQuery } from "@/plugins/data-sources/serverHelpers";
 import Handlebars from "handlebars";
-import { FilterOrFilterGroup } from "../tables/types"
 
 /**
  * This method will filter out record fields that are disconnected.

--- a/pages/data-sources/[dataSourceId].tsx
+++ b/pages/data-sources/[dataSourceId].tsx
@@ -7,11 +7,12 @@ import GoogleSheetsSetup from "@/components/GoogleSheetsSetup";
 import Layout from "@/components/Layout";
 import PageWrapper from "@/components/PageWrapper";
 import React, { useMemo } from "react";
+import Shimmer from "@/components/Shimmer"
 import ShimmerOrCount from "@/components/ShimmerOrCount";
 
 function DataSourcesShow() {
   const { dataSourceId } = useDataSourceContext();
-  const { dataSource } = useDataSourceResponse(dataSourceId);
+  const { dataSource, isLoading: dataSourceIsLoading } = useDataSourceResponse(dataSourceId);
   const { data: tablesResponse, isLoading: tablesAreLoading } =
     useGetTablesQuery({ dataSourceId }, { skip: !dataSourceId });
 
@@ -38,7 +39,7 @@ function DataSourcesShow() {
       <>
         {showGoogleSheetsSetup && <GoogleSheetsSetup />}
         {showGoogleSheetsSetup || (
-          <PageWrapper heading={dataSource?.name}>
+          <PageWrapper heading={dataSourceIsLoading ? <Shimmer height={28} width={120} /> : dataSource?.name}>
             <div>
               This data source has{" "}
               <ShimmerOrCount

--- a/plugins/fields/Association/helpers.ts
+++ b/plugins/fields/Association/helpers.ts
@@ -19,11 +19,11 @@ export const getForeignName = (record: any, column: Column) => {
       if (record.title) prettyName = record.title;
       if (record.name) prettyName = record.name;
     }
+
+    if (prettyName) return `${prettyName} [${record.id}]`;
+
+    if (record && record?.id) return `${record.id}`;
   }
-
-  if (prettyName) return `${prettyName} [${record.id}]`;
-
-  if (record && record.id) return `${record.id}`;
 
   return null;
 };


### PR DESCRIPTION
# Description

When a foreign key record is missing the `/records` API call crashes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
